### PR TITLE
Update scripts.js

### DIFF
--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -152,8 +152,8 @@ function generateBarcode() {
         let expDate = $('#item' + i + '_exp_date').val();
 
         if (expDate.length > 0) {
-            itemString += ",EXP:" + moment(expDate).format('MMDDYY').toString();
-            itemStringHTML += "<strong>, EXP:</strong>" + moment(expDate).format('MMDDYY').toString();
+            itemString += ",EXP:" + moment(expDate).format('YYMMDD').toString();
+            itemStringHTML += "<strong>, EXP:</strong>" + moment(expDate).format('YYMMDD').toString();
         }
 
         items.push(itemString);


### PR DESCRIPTION
Amazon 2d FBA Box content labels require that any applicable expiration dates be in "YYMMDD" format. 

Kindly check this link for source: https://sellercentral.amazon.com/help/hub/reference/external/202049090

I changed the simple code to reflect this requirement.